### PR TITLE
passing behaviors to Tangram through yaml

### DIFF
--- a/examples/example-scene.yaml
+++ b/examples/example-scene.yaml
@@ -19,6 +19,40 @@ layers:
     data: { source: test_geojson }
     draw:
       points:
+        interactive: true
         color: "#f00"
-        size: 10px
+        size: 18px
         order: 1
+
+jupyterlab:
+  tangramEvents:
+    init: |
+      function (map, tangramLayer) {
+        map.setView([37.5749, 126.9761], 14);
+        var getFormattedTable = function(obj) {
+          var table = document.createElement('table');
+          for(var key in obj) {
+            var tr = document.createElement('tr');
+            var keyTd = document.createElement('td');
+            keyTd.textContent = key;
+            var valTd = document.createElement('td');
+            valTd = document.createElement('td');
+            valTd.textContent = obj[key];
+            tr.appendChild(keyTd);
+            tr.appendChild(valTd);
+            table.appendChild(tr);
+          }
+          return table;
+        }
+
+        var popup = L.popup();
+        tangramLayer.setSelectionEvents({
+          click: function(selection) {
+            if (selection.feature && selection.feature.source_name.includes('test')) {
+              popup.setLatLng(selection.leaflet_event.latlng);
+              popup.setContent(getFormattedTable(selection.feature.properties));
+              popup.openOn(map);
+            }
+          }
+        });
+      }

--- a/src/lab_extension.js
+++ b/src/lab_extension.js
@@ -1,80 +1,21 @@
+import '../style/index.css';
+
 import {
   Widget
 } from '@phosphor/widgets';
 
 import * as L from 'leaflet';
+import * as yaml from 'js-yaml';
 import Tangram from 'tangram/dist/tangram.debug';
 
-import '../style/index.css';
 import 'leaflet/dist/leaflet.css';
 
-var yaml = require('js-yaml');
+import { TangramWidget } from './tangram_widget';
 
 /**
  * The default mime type for the extension.
  */
-const MIME_TYPE = 'text/x-yaml';
-
-
-/**
- * The class name added to the extension.
- */
-const CLASS_NAME = 'jp-OutputWidgetYAML';
-
-
-/**
- * A widget for rendering YAML.
- */
-export
-class OutputWidget extends Widget {
-  /**
-   * Construct a new output widget.
-   */
-  constructor(options) {
-    super();
-    this.addClass(CLASS_NAME);
-    this._map = L.map(this.node, {
-        // trackResize option set to false as it is not needed to track
-        // window.resize events since we have individual phosphor resize
-        trackResize: false
-    });
-  }
-
-  /**
-   * Dispose of the widget.
-   */
-  dispose() {
-    // Dispose of leaflet map
-    this._map.remove();
-    this._map = null;
-    super.dispose();
-  }
-
-  /**
-   * Render YAML into this widget's node.
-   */
-  renderModel(model) {
-    var data = model.data[MIME_TYPE];
-    var map = this._map;
-    // TO DO: Make the view flexible to the customized data layer
-    map.setView([37.5749, 126.9761], 14);
-    return new Promise ((resolve, reject) => {
-      var object = yaml.safeLoad(data);
-      var tangramLayer = Tangram.leafletLayer({
-        scene: object
-      });
-      tangramLayer.addTo(map);
-      tangramLayer.on('init', function () {
-        resolve();
-      });
-    })
-  }
-
-  onResize() {
-    this.update();
-  }
-}
-
+export const MIME_TYPE = 'text/x-yaml';
 
 /**
  * A mime renderer factory for YAML data.
@@ -85,10 +26,8 @@ const rendererFactory = {
   mimeTypes: [MIME_TYPE],
   // TO DO: what is right number?
   defaultRank: 5,
-  createRenderer: options => new OutputWidget(options)
+  createRenderer: options => new TangramWidget(options)
 };
-
-
 
 const extension = {
   id: 'jupyterlab_tangram',

--- a/src/tangram_widget.js
+++ b/src/tangram_widget.js
@@ -1,0 +1,76 @@
+import {
+  Widget
+} from '@phosphor/widgets';
+
+import * as L from 'leaflet';
+import * as yaml from 'js-yaml';
+import Tangram from 'tangram/dist/tangram.debug';
+
+import 'leaflet/dist/leaflet.css';
+
+import { MIME_TYPE } from './lab_extension'
+import { parseFunction } from './utils/parse_function'
+/**
+ * The class name added to the extension.
+ */
+const CLASS_NAME = 'jp-OutputWidgetYAML';
+
+/**
+ * A widget for rendering YAML.
+ */
+export
+class TangramWidget extends Widget {
+  /**
+   * Construct a new output widget.
+   */
+  constructor(options) {
+    super();
+    this.addClass(CLASS_NAME);
+    const mapContainer = document.createElement('div');
+    mapContainer.id = 'map';
+    this.node.appendChild(mapContainer);
+    this._map = L.map(mapContainer, {
+        // trackResize option set to false as it is not needed to track
+        // window.resize events since we have individual phosphor resize
+        trackResize: false
+    });
+  }
+
+  /**
+   * Dispose of the widget.
+   */
+  dispose() {
+    // Dispose of leaflet map
+    this._map.remove();
+    this._map = null;
+    super.dispose();
+  }
+
+  /**
+   * Render YAML into this widget's node.
+   */
+  renderModel(model) {
+    var data = model.data[MIME_TYPE];
+    var map = this._map;
+    // TO DO: Make the view flexible to the customized data layer
+    var sceneObject = yaml.safeLoad(data);
+    var tangramLayer = Tangram.leafletLayer({
+      scene: sceneObject
+    });
+    tangramLayer.addTo(map);
+
+    const funcObj = parseFunction(sceneObject.jupyterlab.tangramEvents.init);
+    const initFunction = new Function(funcObj.args, funcObj.body);
+    initFunction(map, tangramLayer);
+
+    return new Promise ((resolve, reject) => {
+      tangramLayer.on('init', function () {
+        resolve();
+      });
+    })
+  }
+
+  onResize() {
+    this.update();
+  }
+}

--- a/src/utils/parse_function.js
+++ b/src/utils/parse_function.js
@@ -1,0 +1,22 @@
+function functionRegex() {
+  return /^(function)?\s*([\w$]*)\s*\(([\w\s,$]*)\)\s*(\{([\w\W\s\S]*)\})?/;
+}
+
+export function parseFunction(fn) {
+  if (typeof fn === 'function') {
+    fn = String(fn);
+  }
+
+  var fnParts = fn.match(functionRegex());
+  var params = fnParts[3] || '';
+  var args = params ? params.split(/\s*\,\s*/) : [];
+
+  return {
+    name: fnParts[2] || 'anonymous',
+    params: params,
+    args: args,
+    body: fnParts[5] || '',
+    called: fnParts[1] !== 'function',
+    defn: fnParts[1] === 'function'
+  };
+}

--- a/style/index.css
+++ b/style/index.css
@@ -7,3 +7,8 @@ div.output_subarea.output_YAML {
   padding: 0;
   max-width: 100%;
 }
+
+#map {
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
- create a section for `jupyterlab`  in yaml, using it to settle the customized behavior
- Lots of details are in question. (ex. how to consist `jupyterlab` other than `init`? is `tangramEvents` necessary? Are there more variables that a user needs access other than `map` and `tangramlayer`? ) but I think I will keep the big structure (using `jupyterlab` block of yaml file to communicate with tangram extension) for a while. 
- related: https://github.com/hanbyul-dl/jupyterlab_tangram/issues/1